### PR TITLE
Set docker image with corresponding go version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build the application
-FROM golang:1.23-bookworm AS builder
+FROM golang:1.24-bookworm AS builder
 
 # Install necessary packages including libpcap-dev
 RUN apt-get update && apt-get install -y libpcap-dev


### PR DESCRIPTION
```
docker build .

[+] Building 2.2s (11/16)                                                                                                                                                                                                  docker:orbstack
 => [internal] load build definition from Dockerfile                                                                                                                                                                                  0.1s
 => => transferring dockerfile: 967B                                                                                                                                                                                                  0.0s
 => [internal] load metadata for docker.io/library/debian:bookworm-slim                                                                                                                                                               1.5s
 => [internal] load metadata for docker.io/library/golang:1.23-bookworm                                                                                                                                                               1.7s
 => [internal] load .dockerignore                                                                                                                                                                                                     0.0s
 => => transferring context: 2B                                                                                                                                                                                                       0.0s
 => [stage-1 1/4] FROM docker.io/library/debian:bookworm-slim@sha256:b1a741487078b369e78119849663d7f1a5341ef2768798f7b7406c4240f86aef                                                                                                 0.0s
 => [builder 1/7] FROM docker.io/library/golang:1.23-bookworm@sha256:167053a2bb901972bf2c1611f8f52c44d5fe7e762e5cab213708d82c421614db                                                                                                 0.0s
 => [internal] load build context                                                                                                                                                                                                     0.0s
 => => transferring context: 234.63kB                                                                                                                                                                                                 0.0s
 => CACHED [builder 2/7] RUN apt-get update && apt-get install -y libpcap-dev                                                                                                                                                         0.0s
 => CACHED [builder 3/7] WORKDIR /app                                                                                                                                                                                                 0.0s
 => CACHED [builder 4/7] COPY go.mod go.sum ./                                                                                                                                                                                        0.0s
 => ERROR [builder 5/7] RUN go mod download                                                                                                                                                                                           0.3s
------                                                                                                                                                                                                                                     
 > [builder 5/7] RUN go mod download:
0.226 go: go.mod requires go >= 1.24.0 (running go 1.23.12; GOTOOLCHAIN=local)
------
Dockerfile:12
--------------------
  10 |     # Copy go.mod and go.sum files and download dependencies
  11 |     COPY go.mod go.sum ./
  12 | >>> RUN go mod download
  13 |     
  14 |     # Copy the application source code
--------------------
ERROR: failed to solve: process "/bin/sh -c go mod download" did not complete successfully: exit code: 1
exit status 1
```