### PR TITLE
Update nmap library to v3; fix tests

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -179,7 +179,6 @@ server:
 scanning:
   interval: 3600
   port_range: "1-1000"
-Scanning:
   rate_limit: 30
   task_queue_size: 50
   worker_count: 3

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -20,7 +20,6 @@ scanning:
   disable_dns_resolution: false
   min_rate: 500
   min_parallelism: 5
-performance:
   rate_limit: 30
   task_queue_size: 50
   worker_count: 3

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/renatogalera/openport-exporter
 go 1.24.0
 
 require (
-	github.com/Ullaakut/nmap v2.0.2+incompatible
+	github.com/Ullaakut/nmap/v3 v3.0.6
 	github.com/c-robinson/iplib v1.0.8
 	github.com/prometheus/client_golang v1.20.5
 	github.com/sirupsen/logrus v1.9.3
@@ -24,6 +24,7 @@ require (
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.55.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
+	golang.org/x/sync v0.7.0 // indirect
 	golang.org/x/sys v0.30.0 // indirect
 	google.golang.org/protobuf v1.34.2 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/Ullaakut/nmap v2.0.2+incompatible h1:edw45QpSQBQ2B/Hqfg86Bt5rrK79tp/fAcqIHyNSdQs=
-github.com/Ullaakut/nmap v2.0.2+incompatible/go.mod h1:fkC066hwfcoKwlI7DS2ARTggSVtBTZYCjVH1TzuTMaQ=
+github.com/Ullaakut/nmap/v3 v3.0.6 h1:ZCQ70TQp97f/YqIFhlzFMDi5xVDeA0CwMbNeJZGA//A=
+github.com/Ullaakut/nmap/v3 v3.0.6/go.mod h1:dd5K68P7LHc5nKrFwQx6EdTt61O9UN5x3zn1R4SLcco=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/c-robinson/iplib v1.0.8 h1:exDRViDyL9UBLcfmlxxkY5odWX5092nPsQIykHXhIn4=
@@ -40,6 +40,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+golang.org/x/sync v0.7.0 h1:YsImfSBoP9QPYL0xyKJPq0gcaJdG3rInoqxTWbfQu9M=
+golang.org/x/sync v0.7.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.30.0 h1:QjkSwP/36a20jFYWkSue1YwXzLmsV5Gfq7Eiy72C1uc=
 golang.org/x/sys v0.30.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/scanner/scanner_test.go
+++ b/scanner/scanner_test.go
@@ -100,6 +100,7 @@ func TestProcessNmapResults(t *testing.T) {
 	result := &nmap.Run{
 		Hosts: []nmap.Host{
 			{
+				Status: nmap.Status{State: "up"},
 				Addresses: []nmap.Address{
 					{Addr: "192.168.1.1"},
 				},

--- a/scanner/scanner_test.go
+++ b/scanner/scanner_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/renatogalera/openport-exporter/config"
 	"github.com/renatogalera/openport-exporter/metrics"
 
-	"github.com/Ullaakut/nmap"
+	"github.com/Ullaakut/nmap/v3"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/time/rate"
 )


### PR DESCRIPTION
https://pkg.go.dev/github.com/Ullaakut/nmap/v3@v3.0.6

```
openport-exporter % go test ./...   
?       github.com/renatogalera/openport-exporter       [no test files]
ok      github.com/renatogalera/openport-exporter/app   (cached)
ok      github.com/renatogalera/openport-exporter/config        (cached)
ok      github.com/renatogalera/openport-exporter/healthcheck   (cached)
ok      github.com/renatogalera/openport-exporter/metrics       (cached)
ok      github.com/renatogalera/openport-exporter/middleware    (cached)
ok      github.com/renatogalera/openport-exporter/scanner       (cached)
```