### PR TITLE
CI: streamlined release pipeline + Pages/Go triggers

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -3,8 +3,12 @@ name: Go CI
 on:
   push:
     branches: ["**"]
+    paths:
+      - '**/*.go'
   pull_request:
     branches: ["**"]
+    paths:
+      - '**/*.go'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,50 @@
+name: GitHub Pages (README only)
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'README.md'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@v4
+        with:
+          source: .
+          destination: ./_site
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./_site
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+


### PR DESCRIPTION
This PR refines CI/CD and Pages workflows with an enterprise-friendly flow:\n\n- Release orchestration on tags (v*): test → docker (pull/no-cache) → goreleaser → bump chart (manual PR).\n- Docker publish on branches only runs tests; publish is gated by tag.\n- Fix Helm chart path to 'chart' and bump workflow to use it.\n- GoReleaser NFPM fields updated (dependencies/recommends) for v2.\n- Pages: deploy only when README.md changes.\n- Go CI: run only when .go files change (push/PR).\n\nThis reduces noise, prevents premature Helm updates, and aligns with enterprise practices.